### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 A Model Context Protocol server for Zotero integration that allows Claude to interact with your Zotero library.
 
+<a href="https://glama.ai/mcp/servers/mjvu0xzzzz"><img width="380" height="200" src="https://glama.ai/mcp/servers/mjvu0xzzzz/badge" alt="Zotero MCP server" /></a>
+
 ## Setup
 
 1. Get your Zotero credentials:


### PR DESCRIPTION
This PR adds a badge for the MCP Zotero server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/mjvu0xzzzz"><img width="380" height="200" src="https://glama.ai/mcp/servers/mjvu0xzzzz/badge" alt="Zotero MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.